### PR TITLE
add documentation for need libvirt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 ## What is it?
 CLI wrapper around http://fog.io to interact with our libvirt hosts.
 
+
+## External dependencies
+
+### libvirt
+
+For OSX run:
+
+    brew install libvirt
+
 ## How to use it
+
 ### Clone the repo
 
 ```


### PR DESCRIPTION
This is an external dependency for running ruby-libvirt gem
